### PR TITLE
Add: ComparedWordCloudPage 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/components/wordcloud-components/Title.js
+++ b/src/components/wordcloud-components/Title.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const Title = () => {
   return (
@@ -6,6 +6,6 @@ const Title = () => {
       <h1>Laws Cloud</h1>
     </div>
   );
-}
+};
 
 export default Title;

--- a/src/routes/ComparedWordCloudPage.js
+++ b/src/routes/ComparedWordCloudPage.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Title from "../components/wordcloud-components/Title";
+import ComparedWordCloudsSection from "./ComparedWordCloudsSection";
+
+function ComparedWordCloudPage({setSearch}) {
+  return (
+    <StyledWrapper>
+      <Title />
+      <ComparedWordCloudsSection setSearch={setSearch} compareNumber={3} cloudSize={70} />
+    </StyledWrapper>
+  );
+}
+
+ComparedWordCloudPage.propTypes = {
+  setSearch: PropTypes.func.isRequired,
+};
+
+export default ComparedWordCloudPage;
+
+const StyledWrapper = styled.div`
+  .compared-wordclouds {
+    display: flex;
+    justify-content: space-between;
+
+    width: 1200px;
+    height: 1400px;
+    padding: 0 100px;
+    margin: 0 auto;
+  }
+`;

--- a/src/routes/ComparedWordCloudsSection.js
+++ b/src/routes/ComparedWordCloudsSection.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+import WordCloudSection from "../components/wordcloud-components/WordCloudSection";
+
+function ComparedWordCloudsSection({setSearch, compareNumber = 3, cloudSize}) {
+  const compareNum = new Array(compareNumber).fill(1).map((elem, i) => elem + i);
+
+  return (
+    <section className="compared-wordclouds">
+      {compareNum.map((num) => (
+        <WordCloudSection setSearch={setSearch} size={cloudSize} elemId={`wordcloud${num}`} key={`wordcloud-${num}`} />
+      ))}
+    </section>
+  );
+}
+
+ComparedWordCloudsSection.propTypes = {
+  setSearch: PropTypes.func.isRequired,
+  compareNumber: PropTypes.number,
+  cloudSize: PropTypes.number.isRequired,
+};
+
+export default ComparedWordCloudsSection;


### PR DESCRIPTION
##기능
워드클라우드 3개를 비교할 수 있는 컴포넌트(페이지)
비교할 워드클라우드의 갯수, 사이즈 지정 가능
##설명
워드클라우드를 여러 개 불러와 비교할 수 있는 컴포넌트 입니다. 사이즈와 갯수를 attribute로 지정할 수 있습니다.
