### PR TITLE
Mod: Title에서 검색 버튼과 타이틀이 겹치는 문제를 해결하였습니다

### DIFF
--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -29,22 +29,25 @@ const Title = () => {
 export default Title;
 
 const Header = styled.header`
+  --title-between: 200px;
+  min-width: 700px;
+
   display: flex;
+  /* display: flex; */
   height: 90px;
   // margin: 0 auto;
   position: relative;
   align-items: center;
   justify-content: center;
+
   h1 {
     // margin: 0 auto;
-    padding: 0;
+    margin-left: calc(62px + var(--title-between));
     text-align: center;
     font-weight: 800;
   }
   img {
-    /* margin: 10px; */
+    margin-left: var(--title-between);
     height: 25px;
-    position: absolute;
-    right: 320px;
   }
 `;


### PR DESCRIPTION
## 기능
Title에서 --title-between 변수를 이용하여 타이틀과 검색 버튼 사이의 거리를 조절할 수 있습니다.
## 설명
최소 width를 설정하고 마진 설정을 변경하여 검색 버튼과 타이틀 사이의 겨리를 일정하게 하였습니다.
closes #41 