### PR TITLE
Fix: 조회수 0이어도 업데이트 되도록 변경

### DIFF
--- a/src/components/TotalViews/TotalViews.js
+++ b/src/components/TotalViews/TotalViews.js
@@ -12,6 +12,8 @@ function TotalViews({billId}) {
   get(child(ref(firebasedatabase), `billId/${billId}`)).then((snapshot) => {
     if (snapshot.exists()) {
       setViewCount(snapshot.val().count);
+    } else {
+      setViewCount(0);
     }
   });
 


### PR DESCRIPTION
## 기능

조회수 0이어도 업데이트 되도록 변경

## 설명

조회수가 없는 발의안은 FireStore 문서가 없어서 업데이트가 되지 않았음
문서가 없는 발의안은 viewCount를 0으로 줘서 해결
